### PR TITLE
fix(home page for storefront): localhost 3000 redirects to 3001

### DIFF
--- a/apps/storefront/next.config.js
+++ b/apps/storefront/next.config.js
@@ -1,4 +1,14 @@
 module.exports = {
   reactStrictMode: true,
   transpilePackages: ['shared-components'],
+  async redirects() {
+    return [
+      {
+        source: '/',
+        destination: 'http://localhost:3001',
+        permanent: true,
+        basePath: false,
+      },
+    ];
+  },
 };


### PR DESCRIPTION
the root of storefront or localhost:3000 will redirect to localhost:3001.  Used next.config.js as per nextjs docs instructions for redirecting.

fix redirect 181